### PR TITLE
Prepare for CDS and ADT development.

### DIFF
--- a/CDS/cds_booking.cds
+++ b/CDS/cds_booking.cds
@@ -1,0 +1,18 @@
+@AbapCatalog.sqlViewName: 'CDS_CUSTOMER'
+@AbapCatalog.compiler.compareFilter: true
+@AbapCatalog.preserveKey: true
+@AccessControl.authorizationCheck: #CHECK
+@EndUserText.label: 'ZCDS_CUSTOMER'
+@OData.entitySet.name: 'FlugkundeSet'
+@OData.entityType.name: 'Flugkunde'
+define view ZCDS_CUSTOMER as select from scustom association [1..*] to ZCDS_BOOKING as booking on  booking.customid = $projection.id {
+    key id,
+    name,
+    form,
+    street,
+    city,
+    postcode,
+    country,
+    region,
+    booking
+}

--- a/CDS/cds_customer.cds
+++ b/CDS/cds_customer.cds
@@ -1,0 +1,18 @@
+@AbapCatalog.sqlViewName: 'CDS_CUSTOMER'
+@AbapCatalog.compiler.compareFilter: true
+@AbapCatalog.preserveKey: true
+@AccessControl.authorizationCheck: #CHECK
+@EndUserText.label: 'ZCDS_CUSTOMER'
+@OData.entitySet.name: 'FlugkundeSet'
+@OData.entityType.name: 'Flugkunde'
+define view ZCDS_CUSTOMER as select from scustom association [1..*] to ZCDS_BOOKING as booking on  booking.customid = $projection.id {
+    key id,
+    name,
+    form,
+    street,
+    city,
+    postcode,
+    country,
+    region,
+    booking
+}

--- a/CDS/cds_flight.cds
+++ b/CDS/cds_flight.cds
@@ -1,0 +1,29 @@
+@AbapCatalog.sqlViewName: 'CDS_FLIGHT'
+@AbapCatalog.compiler.compareFilter: true
+@AbapCatalog.preserveKey: true
+@AccessControl.authorizationCheck: #CHECK
+@EndUserText.label: 'ZCDS_FLIGHT'
+define view ZCDS_FLIGHT as select from sflight {
+    carrid     as CarrierId,
+    connid     as ConnectionId,
+    fldate     as FlightDate,
+    currency_conversion(
+      amount => price,
+      source_currency => currency,
+      target_currency => cast('EUR' as abap.cuky(5)),
+      exchange_rate_date => fldate ) as Price,
+    'EUR' as Currency,
+    planetype  as PlaneType,
+    seatsmax   as MaxSeats,
+    seatsocc   as OccupiedSeats,
+    division(seatsocc, seatsmax, 2) * 100 as UtilizationOverall,
+    seatsmax - seatsmax_b - seatsmax_f as MaxSeatsEconomy,
+    seatsocc - seatsocc_b - seatsocc_f as OccupiedSeatsEconomy,
+    division((seatsocc - seatsocc_b - seatsocc_f), (seatsmax - seatsmax_b - seatsmax_f), 2) * 100 as UtilizationEconomy,
+    seatsmax_b as MaxSeatsBusiness,
+    seatsocc_b as OccupiedSeatsBusiness,
+    division(seatsocc_b, seatsmax_b, 2) * 100 as UtilizationBusiness,
+    seatsmax_f as MaxSeatsFirst,
+    seatsocc_f as OccupiedSeatsFirst,
+    division(seatsocc_f, seatsmax_f, 2) * 100 as UtilizationFirst
+}


### PR DESCRIPTION
CDS Views can be used in mappings from SEGW. This also includes the creation of Navigations without any programming. The following example contains the CDS Views for sflight, scustomer, sbook including the Association between the customer table and the booking table. This can be later used as a SADL Mapping (create mapping for service implementation and change to "Association" after creating the navigation properties). If the class continues and is being developed further (away form using a MiniSAP and instead using the ADT) it will come in handy to have code ready for CDS Views and asociations respectively. The Tags @ODataEntityType.name etc. are usefull if the lecturer wants to show how a service is being auto-generated by adding the respective annotation.